### PR TITLE
Add MANIFEST.in.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+include CHANGES.txt
+include README.rst
+recursive-include docs *.rst *.py *.bat
+include docs/Makefile


### PR DESCRIPTION
Without a `MANIFEST.in` file, `python setup.py sdist` does not include `CHANGES.txt` or `README.rst` in the packaged sdist, which breaks installation because `setup.py` references these files. This pull request fixes that.

I also chose to include the documentation in the packaged sdist, as I generally consider that a good practice, but this could be removed if you don't want it.

I presume you must not be using `python setup.py sdist` to generate the sdists on PyPI, or they would be broken too?
