### PR TITLE
Don't render reST comments in slide output.

### DIFF
--- a/hovercraft/templates/reST.xsl
+++ b/hovercraft/templates/reST.xsl
@@ -419,4 +419,7 @@
 	</span>
 </xsl:template>
 
+<xsl:template match="comment">
+</xsl:template>
+
 </xsl:stylesheet>

--- a/hovercraft/tests/test_data/comment.rst
+++ b/hovercraft/tests/test_data/comment.rst
@@ -1,0 +1,5 @@
+----
+
+This text should appear.
+
+.. This comment should not.

--- a/hovercraft/tests/test_generator.py
+++ b/hovercraft/tests/test_generator.py
@@ -147,6 +147,21 @@ class GeneratorTests(unittest.TestCase):
         
         self.assertEqual(html, target)
 
+    def test_comments(self):
+        template = Template(os.path.join(TEST_DATA, 'minimal'))
+        html = rst2html(os.path.join(TEST_DATA, 'comment.rst'), template)
+        target = (
+            b'<!DOCTYPE html><html xmlns="http://www.w3.org/1999/xhtml">'
+            b'<body><div id="impress">'
+            b'<div class="step" step="0" data-x="0" data-y="0">'
+            b'<p>This text should appear.</p></div></div>'
+            b'<script type="text/javascript" src="js/impress.js"></script>'
+            b'<script type="text/javascript" src="js/hovercraft-minimal.js">'
+            b'</script></body></html>')
+        
+        self.assertEqual(html, target)
+
+
 if __name__ == '__main__':
     unittest.main()
     


### PR DESCRIPTION
I noticed that reST comments were being rendered in slide output as plain text. This is problematic if you're testing your slides with Manuel, as Manuel makes use of reST comments for things like output capturing, invisible-code-block, etc. I added a simple template in reST.xsl to prevent comments from rendering at all. (I suppose an alternative would be to render them as HTML comments, but I really don't see the use case.)
