### PR TITLE
Adding configparser to install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(name='hovercraft',
       include_package_data=True,
       zip_safe=True,
       install_requires=[
+          'configparser >= 3.3.0r2',
           'docutils >= 0.9',
           'lxml>=3.1.0',
           'svg.path',


### PR DESCRIPTION
Hi there, I tried to install on my machine using the setup.py, but when used the hovercraft cmd it required the configparser package.

So I added it to the install_requires =)
