### PR TITLE
Add configparser as requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(name='hovercraft',
           'lxml>=3.1.0',
           'svg.path',
           'pygments',
+          'configparser'
       ],
       tests_require=[
           'manuel',


### PR DESCRIPTION
Adding configparser as requirement

After a fresh install via pip I got this:  

```
mgaitan@traful:~/Documentos/slides/phasety+idtq$ hovercraft charla.rst html/
Traceback (most recent call last):
  File "/usr/local/bin/hovercraft", line 9, in <module>
    load_entry_point('hovercraft==1.1', 'console_scripts', 'hovercraft')()
  File "/usr/local/lib/python2.7/dist-packages/hovercraft/__init__.py", line 18, in main
    from hovercraft.generate import rst2html, copy_resource
  File "/usr/local/lib/python2.7/dist-packages/hovercraft/generate.py", line 8, in <module>
    from .template import CSS_RESOURCE
  File "/usr/local/lib/python2.7/dist-packages/hovercraft/template.py", line 2, in <module>
    import configparser
ImportError: No module named configparser
```

After install configparser it worked. 
