### PR TITLE
support python2.7 by using ConfigParser

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,4 @@
 from setuptools import setup, find_packages
-import sys
-if sys.version < '3':
-    print("Hovercraft requires Python 3.2 or higher.")
-    sys.exit(1)
 
 version = '1.2.dev0'
 


### PR DESCRIPTION
Hi, if the only reason for requiring python3 is configparser then we can use ConfigParser as a fallback. I tested it a bit with my python2.7 and hovercraft seems to works fine. Do you think we can drop the python3 requirement?
