### PR TITLE
handle the 'image' attribute 'align'

### DIFF
--- a/hovercraft/templates/reST.xsl
+++ b/hovercraft/templates/reST.xsl
@@ -122,6 +122,11 @@ Modification by Carl Mayer, 2013:
 		<xsl:attribute name="height">
 			<xsl:value-of select="@height" />
 		</xsl:attribute>
+		<xsl:if test="@align">
+			<xsl:attribute name="class">
+				<xsl:value-of select="concat('image-align-', @align)" />
+			</xsl:attribute>
+		</xsl:if>
 	</xsl:element>
 </xsl:template>
 


### PR DESCRIPTION
Currently the 'align' attribute for images is ignored.
See http://docutils.sourceforge.net/docs/ref/rst/directives.html#image
for usage details.
The following css definitions are recommended to handle the introduced
'image-align-(left|center|right|top|middle|bottom)' classes:

  .image-align-left { display: block; margin-right: auto; }
  .image-align-center { display: block; margin-left: auto; margin-right: auto; }
  .image-align-right { display: block; margin-left: auto; }
  .image-align-top { vertical-align: top; }
  .image-align-middle { vertical-align: middle; }
  .image-align-bottom { vertical-align: bottom; }

Is my understanding correct, that the above definitions should not be part of hovercraft's css templates?
