### PR TITLE
Integration of the extension impress.js-progress

### DIFF
--- a/docs/presentations.rst
+++ b/docs/presentations.rst
@@ -244,7 +244,9 @@ them first in the document, or first on a slide.
 
 Any fields you put first in a document will be rendered into attributes on
 the main impress.js ``<div>``. This is currently only used to set the
-transition-duration with ``data-transition-duration``.
+transition-duration with ``data-transition-duration`` and chose wheater 
+a progress bar or a simple counter is displayed on each slide, with 
+``progressbar`` or ``progress``.
 
 Any fields you put first in a slide will be rendered into attributes on the
 slide ``<div>``. This is used primarily to set the position/zoom/rotation of
@@ -262,6 +264,8 @@ A presentation can therefore look something like this::
     :skip-help: true
 
     .. title: Presentation Title
+    
+    :progressbar: yes
     
     ----
 

--- a/hovercraft/templates/default/css/impress-progress.css
+++ b/hovercraft/templates/default/css/impress-progress.css
@@ -1,0 +1,28 @@
+.progressbar {
+	position:absolute;
+	right:118px;
+	bottom:15px;
+	left:118px;
+	border-radius:7px;
+	border:2px solid rgba(100, 100, 100, 0.2);
+}
+.progressbar DIV {
+	width:0;
+	height:10px;
+	border-radius:5px;
+	background:rgba(75, 75, 75, 0.4);
+	-webkit-transition:width 1s linear;
+	-moz-transition:width 1s linear;
+	-ms-transition:width 1s linear;
+	-o-transition:width 1s linear;
+	transition:width 1s linear;
+}
+.progress-off {
+	z-index:2999;
+}
+.progress {
+	position:absolute;
+	right:50px;
+	bottom:15px;
+	text-align: right;
+}

--- a/hovercraft/templates/default/js/impress-progress.js
+++ b/hovercraft/templates/default/js/impress-progress.js
@@ -1,0 +1,35 @@
+(function ( document, window ) {
+    'use strict';
+    
+	var stepids = [];
+	// wait for impress.js to be initialized
+	document.addEventListener("impress:init", function (event) {
+		var steps = event.detail.steps;
+		for (var i = 0; i < steps.length; i++)
+		{
+		  stepids[i+1] = steps[i].id;
+		}
+	});
+	var progressbar = document.querySelector('div.progressbar div');
+	var progress = document.querySelector('div.progress');
+	
+	if (null !== progressbar || null !== progress) {      
+		document.addEventListener("impress:starttransition", function (event) {
+			updateProgressbar(event.detail.next.id);
+		});
+		
+		document.addEventListener("impress:stepenter", function (event) {
+			updateProgressbar(event.target.id);
+		});
+	}
+		
+	function updateProgressbar(slideId) {
+		var slideNumber = stepids.indexOf(slideId);
+		if (null !== progressbar) {
+			progressbar.style.width = (100 / (stepids.length - 1) * (slideNumber)).toFixed(2) + '%';
+		}
+		if (null !== progress) {
+			progress.innerHTML = slideNumber + '/' + (stepids.length-1);
+		}
+	}
+})(document, window);

--- a/hovercraft/templates/default/template.cfg
+++ b/hovercraft/templates/default/template.cfg
@@ -4,7 +4,9 @@ template = template.xsl
 css = css/hovercraft.css
       css/impressConsole.css
       css/highlight.css
+      css/impress-progress.css
 
-js-body = js/impress.js
+js-body = js/impress-progress.js
+	  js/impress.js
           js/impressConsole.js
           js/hovercraft.js

--- a/hovercraft/templates/default/template.xsl
+++ b/hovercraft/templates/default/template.xsl
@@ -69,14 +69,22 @@ xmlns="http://www.w3.org/1999/xhtml">
       </div> 
     </xsl:for-each>
   
+    <xsl:if test="/document/@progressbar">
+    	<div class="progressbar"><div></div></div>	
+    </xsl:if>
+    
+    <xsl:if test="/document/@progress">
+    	<div class="progress"><div></div></div>	
+    </xsl:if>
+
     <div id="hovercraft-help">
       <xsl:if test="/document/@skip-help">
         <xsl:attribute name="class">hide</xsl:attribute>
       </xsl:if>
       <table>
         <tr><th>Space</th><td>Forward</td></tr>
-        <tr><th>Right, Down, Page Down</th><td>Next slide</td></tr>
-        <tr><th>Left, Up, Page Up</th><td>Previous slide</td></tr>
+        <tr><th>Left, Down, Page Down</th><td>Next slide</td></tr>
+        <tr><th>Right, Up, Page Up</th><td>Previous slide</td></tr>
         <tr><th>P</th><td>Open presenter console</td></tr>
         <tr><th>H</th><td>Toggle this help</td></tr>
       </table>

--- a/hovercraft/templates/simple/css/impress-progress.css
+++ b/hovercraft/templates/simple/css/impress-progress.css
@@ -1,0 +1,28 @@
+.progressbar {
+	position:absolute;
+	right:118px;
+	bottom:15px;
+	left:118px;
+	border-radius:7px;
+	border:2px solid rgba(100, 100, 100, 0.2);
+}
+.progressbar DIV {
+	width:0;
+	height:10px;
+	border-radius:5px;
+	background:rgba(75, 75, 75, 0.4);
+	-webkit-transition:width 1s linear;
+	-moz-transition:width 1s linear;
+	-ms-transition:width 1s linear;
+	-o-transition:width 1s linear;
+	transition:width 1s linear;
+}
+.progress-off {
+	z-index:2999;
+}
+.progress {
+	position:absolute;
+	right:50px;
+	bottom:15px;
+	text-align: right;
+}

--- a/hovercraft/templates/simple/js/impress-progress.js
+++ b/hovercraft/templates/simple/js/impress-progress.js
@@ -1,0 +1,35 @@
+(function ( document, window ) {
+    'use strict';
+    
+	var stepids = [];
+	// wait for impress.js to be initialized
+	document.addEventListener("impress:init", function (event) {
+		var steps = event.detail.steps;
+		for (var i = 0; i < steps.length; i++)
+		{
+		  stepids[i+1] = steps[i].id;
+		}
+	});
+	var progressbar = document.querySelector('div.progressbar div');
+	var progress = document.querySelector('div.progress');
+	
+	if (null !== progressbar || null !== progress) {      
+		document.addEventListener("impress:starttransition", function (event) {
+			updateProgressbar(event.detail.next.id);
+		});
+		
+		document.addEventListener("impress:stepenter", function (event) {
+			updateProgressbar(event.target.id);
+		});
+	}
+		
+	function updateProgressbar(slideId) {
+		var slideNumber = stepids.indexOf(slideId);
+		if (null !== progressbar) {
+			progressbar.style.width = (100 / (stepids.length - 1) * (slideNumber)).toFixed(2) + '%';
+		}
+		if (null !== progress) {
+			progress.innerHTML = slideNumber + '/' + (stepids.length-1);
+		}
+	}
+})(document, window);

--- a/hovercraft/templates/simple/template.cfg
+++ b/hovercraft/templates/simple/template.cfg
@@ -3,6 +3,8 @@ template = template.xsl
 
 css = css/hovercraft.css
       css/highlight.css
+      css/impress-progress.css
 
-js-body = js/impress.js
+js-body = js/impress-progress.js
+	  js/impress.js
           js/hovercraft.js

--- a/hovercraft/templates/simple/template.xsl
+++ b/hovercraft/templates/simple/template.xsl
@@ -10,7 +10,29 @@ xmlns="http://www.w3.org/1999/xhtml">
 <html>
   <head>
     <title><xsl:value-of select="/document/@title"/></title>
-
+    <meta name="generator" content="Hovercraft! 1.0 http://regebro.github.com/hovercraft"/>
+    <xsl:if test="/document/author"> <!-- Author is a child to the document, everything else become attributes -->
+      <meta name="author">
+        <xsl:attribute name="content">
+          <xsl:value-of select="/document/author" />
+        </xsl:attribute>
+      </meta>
+    </xsl:if>
+    <xsl:if test="/document/@description">
+      <meta name="description">
+        <xsl:attribute name="content">
+          <xsl:value-of select="/document/@description" />
+        </xsl:attribute>
+      </meta>
+    </xsl:if>
+    <xsl:if test="/document/@keywords">
+      <meta name="keywords">
+        <xsl:attribute name="content">
+          <xsl:value-of select="/document/@keywords" />
+        </xsl:attribute>
+      </meta>
+    </xsl:if>
+    
     <xsl:for-each select="/document/templateinfo/header/css">
       <link rel="stylesheet">
         <xsl:copy-of select="@*"/>
@@ -47,16 +69,23 @@ xmlns="http://www.w3.org/1999/xhtml">
       </div> 
     </xsl:for-each>
   
+    <xsl:if test="/document/@progressbar">
+    	<div class="progressbar"><div></div></div>	
+    </xsl:if>
+    
+    <xsl:if test="/document/@progress">
+    	<div class="progress"><div></div></div>	
+    </xsl:if>
+
     <div id="hovercraft-help">
-      <xsl:if test="not(/document/@skip-help)">
-        <xsl:attribute name="class">show</xsl:attribute>
-      </xsl:if>
       <xsl:if test="/document/@skip-help">
         <xsl:attribute name="class">hide</xsl:attribute>
       </xsl:if>
       <table>
-        <tr><th>Left, Down, Page Down, Space</th><td>Next slide</td></tr>
+        <tr><th>Space</th><td>Forward</td></tr>
+        <tr><th>Left, Down, Page Down</th><td>Next slide</td></tr>
         <tr><th>Right, Up, Page Up</th><td>Previous slide</td></tr>
+        <tr><th>P</th><td>Open presenter console</td></tr>
         <tr><th>H</th><td>Toggle this help</td></tr>
       </table>
     </div>


### PR DESCRIPTION
Love hovercraft simplicity but absolutely need numbered slides for scientific/academic presentations.
I found  the ``impress.js-progress`` extension from m42e and then added its files into ``default/template.cfg`` and ``simple/template.cfg``.
Then added two simple <xsl:test> in ``template.xsl`` in order to add one pair of new parameters in .rst files: ``progressbar`` and ``progress``.
Eventually added one sentence in the help file.
Still very basic and should be improved to be more versatile. 