### PR TITLE
Ensure that multiple :css: declarations are added as individual resources

### DIFF
--- a/hovercraft/generate.py
+++ b/hovercraft/generate.py
@@ -38,11 +38,13 @@ def rst2html(filepath, template_info, auto_console=False, skip_help=False, skip_
                 dummy, media = attrib.split('-', 1)
             else:
                 media = 'screen,projection'
-            template_info.add_resource(
-                os.path.abspath(os.path.join(presentation_dir, tree.attrib[attrib])),
-                CSS_RESOURCE,
-                target=tree.attrib[attrib],
-                extra_info=media)
+            css_files = tree.attrib[attrib].split()
+            for css_file in css_files:
+                template_info.add_resource(
+                    os.path.abspath(os.path.join(presentation_dir, css_file)),
+                    CSS_RESOURCE,
+                    target=css_file,
+                    extra_info=media)
 
     # Position all slides
     position_slides(tree)


### PR DESCRIPTION
I ran into this error today when attemping to test out hovercraft with the following test presentation file:

```
$ hovercraft presentation.rst
Serving HTTP on 0.0.0.0 port 8000 ...
Exception in thread Thread-1:
Traceback (most recent call last):
  File "/usr/local/Cellar/python3/3.4.3_2/Frameworks/Python.framework/Versions/3.4/lib/python3.4/threading.py", line 920, in _bootstrap_inner
    self.run()
  File "/usr/local/Cellar/python3/3.4.3_2/Frameworks/Python.framework/Versions/3.4/lib/python3.4/threading.py", line 868, in run
    self._target(*self._args, **self._kwargs)
  File "/usr/local/lib/python3.4/site-packages/hovercraft/__init__.py", line 31, in generate_and_observe
    monitor_list = generate(args)
  File "/usr/local/lib/python3.4/site-packages/hovercraft/generate.py", line 120, in generate
    source_files.extend(template_info.copy_resources(args.targetdir))
  File "/usr/local/lib/python3.4/site-packages/hovercraft/template.py", line 182, in copy_resources
    yield self.copy_resource(resource, targetdir)
  File "/usr/local/lib/python3.4/site-packages/hovercraft/template.py", line 177, in copy_resource
    shutil.copy2(source_path, target_path)
  File "/usr/local/Cellar/python3/3.4.3_2/Frameworks/Python.framework/Versions/3.4/lib/python3.4/shutil.py", line 245, in copy2
    copyfile(src, dst, follow_symlinks=follow_symlinks)
  File "/usr/local/Cellar/python3/3.4.3_2/Frameworks/Python.framework/Versions/3.4/lib/python3.4/shutil.py", line 108, in copyfile
    with open(src, 'rb') as fsrc:
FileNotFoundError: [Errno 2] No such file or directory: '/Users/Schoens/Repositories/test_presentation/css/merriweather.css css/lato.css css/presentation.css'

^C
Keyboard interrupt received, exiting.
```

```rst
:css: css/merriweather.css
:css: css/lato.css
:css: css/presentation.css
:data-transition-duration: 2000
:skip-help: true

.. title: Test

----

This is the first slide
=======================

Here comes some text.

----

This is the second slide
========================

#. Here we have

#. A numbered list

#. It will get correct

#. Numbers automatically
```

As you can see the resource path for the css files has not been split, so the error is thrown. I've modified `generate.py` to always split the path before adding the resources to ensure that it adds each one individually as expected.

Let me know if this is just due to me using things wrong, but based on the documentation I think this is probably a bug.