### PR TITLE
filename part of css_base

### DIFF
--- a/hovercraft/generate.py
+++ b/hovercraft/generate.py
@@ -132,7 +132,7 @@ def generate(args):
         if resource.resource_type != CSS_RESOURCE:
             continue
         # path in CSS is relative to CSS file; construct source/dest accordingly
-        css_base = template_info.template if resource.is_in_template else sourcedir
+        css_base = os.path.dirname(template_info.template) if resource.is_in_template else sourcedir
         css_sourcedir = os.path.dirname(os.path.join(css_base, resource.filepath))
         css_targetdir = os.path.dirname(os.path.join(args.targetdir, resource.final_path()))
         uris = RE_CSS_URL.findall(template_info.read_data(resource))


### PR DESCRIPTION
only use directory-part, not including file-name of template.cfg, for css_base variable:
- I have a css file to include a locally stored font that is included via src:url('../fonts/') and the path generated by hovercraft was wrong as it includes "template.cfg".