### PR TITLE
Prevent loop from using 100% CPU.

### DIFF
--- a/hovercraft/__init__.py
+++ b/hovercraft/__init__.py
@@ -44,6 +44,7 @@ def generate_and_observe(args, event):
 
         observer.start()
         while event.wait(1):
+            time.sleep(0.05)  # small delay to avoid using 100% CPU
             if handler.quit:
                 break
 


### PR DESCRIPTION
In the loop that waits for file changes, event.wait() never blocks,
meaning that the loop runs full speed, consuming 100% CPU.

This change introduces a small delay to mitigate this.