### PR TITLE
Fix working directory

### DIFF
--- a/hovercraft/__init__.py
+++ b/hovercraft/__init__.py
@@ -126,6 +126,8 @@ def main():
     if args.template and args.template not in ('simple', 'default'):
         args.template = os.path.abspath(args.template)
 
+    args.basedir = os.getcwd()
+
     if args.build:
         # Generate the presentation
         generate(args)
@@ -155,7 +157,6 @@ def start_server(args):
 
         # First create the server. This checks that we can connect to
         # the port we want to.
-        os.chdir(args.targetdir)
         server = HTTPServer((bind, port), SimpleHTTPRequestHandler)
         print("Serving HTTP on", bind, "port", port, "...")
 

--- a/hovercraft/__init__.py
+++ b/hovercraft/__init__.py
@@ -136,7 +136,7 @@ def main():
         else:
             with TemporaryDirectory() as targetdir:
                 args.targetdir = targetdir
-                start_server(targetdir)
+                start_server(args)
 
 def start_server(args):
     args.targetdir = targetdir

--- a/hovercraft/__init__.py
+++ b/hovercraft/__init__.py
@@ -128,6 +128,10 @@ def main():
 
     args.basedir = os.getcwd()
 
+
+    if args.targetdir and not os.path.exists(args.targetdir):
+        os.makedirs(args.targetdir)
+
     if args.build:
         # Generate the presentation
         generate(args)

--- a/hovercraft/__init__.py
+++ b/hovercraft/__init__.py
@@ -139,7 +139,6 @@ def main():
                 start_server(args)
 
 def start_server(args):
-    args.targetdir = targetdir
     args.presentation = os.path.abspath(args.presentation)
 
     # Set up watchdog to regenerate presentation if saved.
@@ -156,7 +155,7 @@ def start_server(args):
 
         # First create the server. This checks that we can connect to
         # the port we want to.
-        os.chdir(targetdir)
+        os.chdir(args.targetdir)
         server = HTTPServer((bind, port), SimpleHTTPRequestHandler)
         print("Serving HTTP on", bind, "port", port, "...")
 

--- a/hovercraft/generate.py
+++ b/hovercraft/generate.py
@@ -109,10 +109,14 @@ def generate(args):
         template_info.add_resource(args.css, CSS_RESOURCE, target=target_path, extra_info='all')
         source_files.append(args.css)
 
-    with os.chdir(args.basedir):
-        # Make the resulting HTML
+    # Make the resulting HTML (generation is relative to the basedir)
+    saved_cwd = os.getcwd()
+    os.chdir(args.basedir)
+    try:
         htmldata = rst2html(args.presentation, template_info, args.auto_console, args.skip_help,
                             args.skip_notes)
+    finally:
+        os.chdir(saved_cwd)
 
     # Write the HTML out
     with open(os.path.join(args.targetdir, 'index.html'), 'wb') as outfile:

--- a/hovercraft/generate.py
+++ b/hovercraft/generate.py
@@ -115,8 +115,6 @@ def generate(args):
                             args.skip_notes)
 
     # Write the HTML out
-    if not os.path.exists(args.targetdir):
-        os.makedirs(args.targetdir)
     with open(os.path.join(args.targetdir, 'index.html'), 'wb') as outfile:
         outfile.write(htmldata)
 

--- a/hovercraft/generate.py
+++ b/hovercraft/generate.py
@@ -97,6 +97,8 @@ def copy_resource(filename, sourcedir, targetdir):
 def generate(args):
     """Generates the presentation and returns a list of files used"""
 
+    os.chdir(args.targetdir)
+
     source_files = [args.presentation]
 
     # Parse the template info
@@ -107,9 +109,10 @@ def generate(args):
         template_info.add_resource(args.css, CSS_RESOURCE, target=target_path, extra_info='all')
         source_files.append(args.css)
 
-    # Make the resulting HTML
-    htmldata = rst2html(args.presentation, template_info, args.auto_console, args.skip_help,
-                        args.skip_notes)
+    with os.chdir(args.basedir):
+        # Make the resulting HTML
+        htmldata = rst2html(args.presentation, template_info, args.auto_console, args.skip_help,
+                            args.skip_notes)
 
     # Write the HTML out
     if not os.path.exists(args.targetdir):


### PR DESCRIPTION
The underlying pull-request fixes the working directory problem.

Now when generating html (from rst) the working directory is the current one. In the other cases (when creating files) the working directory is the argument targetdir. The directory changing is now performed in the function `generate` so any kind of build (build or start) have the same generating behaviour.

Also, the argument `targetdir` is more consistent because now you can always specify the targetdir (even when you perform build) and the argument `build` has been introduced to decide if a build should be performed or a webserver should be started.

It also fixes issue #96 so you can specify relative paths correctly.

I've already tested extensively the changes.

-----

Thanks,
Alessandro