### PR TITLE
Support for additional javascript files, both from console and rst.

### DIFF
--- a/docs/presentations.rst
+++ b/docs/presentations.rst
@@ -137,8 +137,16 @@ CSS media::
 You can specify any number of css files in this way.
 You can also add one extra CSS-file via a command-line parameter:
 
-    hovercraft --extra-css=my_extra.css presentationfile.rst outdir/
+    hovercraft --css=my_extra.css presentationfile.rst outdir/
 
+In a similar fashion you can add Javascript files to either header or body::
+
+    :js-header: js/firstjsfile.js
+    :js-body: js/secondjsfile.js
+
+You can also add one extra Javascript-file via a command-line parameter:
+
+    hovercraft --js=my_extra.js presentationfile.rst outdir/
 
 Styling a specific slide
 ........................

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -19,7 +19,7 @@ everytime you save a file, you only need to refresh the browser.
 Parameters
 ----------
 
-``hovercraft [-h] [-t TEMPLATE] [-c CSS] [-a] [-s] [-n] [-p PORT] <presentation> [<targetdir>]``
+``hovercraft [-h] [-t TEMPLATE] [-c CSS] [-j JS] [-a] [-s] [-n] [-p PORT] <presentation> [<targetdir>]``
 
 Positional arguments:
 
@@ -43,6 +43,10 @@ Optional arguments:
     ``-c CSS, --css CSS``
         An additional CSS file for the presentation to use.
         See also the ``:css:`` settings of the presentation.
+
+    ``-j JS, --js JS``
+        An additional Javascript file for the presentation to use. Added as a js-body script.
+        See also the ``:js-body:`` settings of the presentation.
 
     ``-a, --auto-console``
         Open the presenter console automatically. This is useful when you are

--- a/hovercraft/__init__.py
+++ b/hovercraft/__init__.py
@@ -91,6 +91,11 @@ def main():
         help=('An additional css file for the presentation to use. '
               'See also the ``:css:`` settings of the presentation.'))
     parser.add_argument(
+        '-j',
+        '--js',
+        help=('An additional javascript file for the presentation to use. Added as a js-body script.'
+              'See also the ``:js-body:`` settings of the presentation.'))
+    parser.add_argument(
         '-a',
         '--auto-console',
         action='store_true',

--- a/hovercraft/generate.py
+++ b/hovercraft/generate.py
@@ -6,7 +6,7 @@ from pkg_resources import resource_string
 
 from .parse import rst2xml, SlideMaker
 from .position import position_slides
-from .template import Template, CSS_RESOURCE
+from .template import Template, CSS_RESOURCE, JS_RESOURCE, JS_POSITION_HEADER, JS_POSITION_BODY, OTHER_RESOURCE
 
 
 class ResourceResolver(etree.Resolver):
@@ -44,6 +44,19 @@ def rst2html(filepath, template_info, auto_console=False, skip_help=False, skip_
                     os.path.abspath(os.path.join(presentation_dir, css_file)),
                     CSS_RESOURCE,
                     target=css_file,
+                    extra_info=media)
+        if attrib.startswith('js'):
+            if attrib == 'js-header':
+                media = JS_POSITION_HEADER
+            else:
+                # Put javascript in body tag as default.
+                media = JS_POSITION_BODY
+            js_files = tree.attrib[attrib].split()
+            for js_file in js_files:
+                template_info.add_resource(
+                    os.path.abspath(os.path.join(presentation_dir, js_file)),
+                    JS_RESOURCE,
+                    target=js_file,
                     extra_info=media)
 
     # Position all slides
@@ -106,6 +119,11 @@ def generate(args):
         target_path = os.path.relpath(args.css, presentation_dir)
         template_info.add_resource(args.css, CSS_RESOURCE, target=target_path, extra_info='all')
         source_files.append(args.css)
+    if args.js:
+        presentation_dir = os.path.split(args.presentation)[0]
+        target_path = os.path.relpath(args.js, presentation_dir)
+        template_info.add_resource(args.js, JS_RESOURCE, target=target_path, extra_info=JS_POSITION_BODY)
+        source_files.append(args.js)
 
     # Make the resulting HTML
     htmldata, dependencies = rst2html(args.presentation, template_info,

--- a/hovercraft/template.py
+++ b/hovercraft/template.py
@@ -150,7 +150,7 @@ class Template(object):
     def copy_resource(self, resource, targetdir):
         """Copies a resource file and returns the source path for monitoring"""
         final_path = resource.final_path()
-        if final_path[0] == '/' or ':' in final_path:
+        if final_path[0] == '/' or (':' in final_path) or ('?' in final_path):
             # Absolute path or URI: Do nothing
             return None
 

--- a/hovercraft/tests/test_data/__init__.py
+++ b/hovercraft/tests/test_data/__init__.py
@@ -44,6 +44,34 @@ HTML_OUTPUTS = {
         b'src="js/hovercraft.js"></script></body></html>'
     ),
 
+    'extra_js': (
+        b'<!DOCTYPE html SYSTEM "about:legacy-compat"><html '
+        b'xmlns="http://www.w3.org/1999/xhtml"><head><title></title><link '
+        b'rel="stylesheet" href="css/style.css" media="all"></link><link '
+        b'rel="stylesheet" href="css/print.css" media="print"></link><link '
+        b'rel="stylesheet" href="css/impressConsole.css" '
+        b'media="screen,projection"></link><script type="text/javascript" '
+        b'src="js/dummy.js"></script></head><body '
+        b'class="impress-not-supported"><div id="impress"><div class="step '
+        b'step-level-1" step="0" data-rotate-x="0" data-rotate-y="0" '
+        b'data-rotate-z="0" data-scale="1" data-x="0" data-y="0" data-z="0">'
+        b'<h1 id="simple-presentation">Simple Presentation</h1><p>This '
+        b'presentation has two slides, each with a header and some text.</p>'
+        b'</div><div class="step step-level-1" step="1" data-rotate-x="0" '
+        b'data-rotate-y="0" data-rotate-z="0" data-scale="1" data-x="1600" '
+        b'data-y="0" data-z="0"><h1 id="second-slide">Second '
+        b'slide</h1><p>There is no positioning or anything '
+        b'fancy.</p></div></div><div id="hovercraft-help" '
+        b'class="show"><table><tr><th>Left, Down, Page Down, Space</th><td>'
+        b'Next slide</td></tr><tr><th>Right, Up, Page Up</th><td>Previous '
+        b'slide</td></tr><tr><th>H</th><td>Toggle this help</td>'
+        b'</tr></table></div><script type="text/javascript" '
+        b'src="js/impress.js"></script><script type="text/javascript" '
+        b'src="js/impressConsole.js"></script><script type="text/javascript" '
+        b'src="js/hovercraft.js"></script><script type="text/javascript" '
+        b'src="extra.js"></script></body></html>'
+    ),
+
     'advanced': (
         b'<!DOCTYPE html SYSTEM "about:legacy-compat"><html '
         b'xmlns="http://www.w3.org/1999/xhtml"><head><title>Presentation '
@@ -91,7 +119,8 @@ HTML_OUTPUTS = {
         b'this help</td></tr></table></div><script type="text/javascript" '
         b'src="js/impress.js"></script><script type="text/javascript" '
         b'src="js/impressConsole.js"></script><script type="text/javascript" '
-        b'src="js/hovercraft.js"></script></body></html>'
+        b'src="js/hovercraft.js"></script><script type="text/javascript" '
+        b'src="extra.js"></script></body></html>'
     ),
 
     'default-template': (
@@ -143,7 +172,8 @@ HTML_OUTPUTS = {
         b'this help</td></tr></table></div><script type="text/javascript" '
         b'src="js/impress.js"></script><script type="text/javascript" '
         b'src="js/impressConsole.js"></script><script type="text/javascript" '
-        b'src="js/hovercraft.js"></script></body></html>'
+        b'src="js/hovercraft.js"></script><script type="text/javascript" '
+        b'src="extra.js"></script></body></html>'
     ),
 
     'presenter-notes': (

--- a/hovercraft/tests/test_data/advanced.rst
+++ b/hovercraft/tests/test_data/advanced.rst
@@ -3,6 +3,7 @@
 :data-transition-duration: 2000
 :auto-console: True
 :css-screen: extra.css
+:js-body: extra.js
 
 
 This is an advanced presentation. It doesn't have a section in the first

--- a/hovercraft/tests/test_data/extra.js
+++ b/hovercraft/tests/test_data/extra.js
@@ -1,0 +1,1 @@
+ /* An empty javascript file to test the command line javascript support. */

--- a/hovercraft/tests/test_hovercraft.py
+++ b/hovercraft/tests/test_hovercraft.py
@@ -49,6 +49,26 @@ class HTMLTests(unittest.TestCase):
             self.assertEqual(set(out_files),
                              {'extra.css', 'index.html', 'js', 'css', 'images', 'fonts'})
 
+    def test_extra_js(self):
+        with TemporaryDirectory() as tmpdir:
+            sys.argv = [
+                'bin/hovercraft',
+                '-t' + os.path.join(TEST_DATA, 'maximal'),
+                '-j' + os.path.join(TEST_DATA, 'extra.js'),
+                '-n',
+                os.path.join(TEST_DATA, 'simple.rst'),
+                tmpdir,
+            ]
+
+            main()
+
+            with open(os.path.join(tmpdir, 'index.html'), 'rb') as outfile:
+                self.assertEqual(outfile.read(), HTML_OUTPUTS['extra_js'])
+
+            out_files = os.listdir(tmpdir)
+            self.assertEqual(set(out_files),
+                             {'extra.js', 'index.html', 'js', 'css', 'images', 'fonts'})
+
     def test_big(self):
         with TemporaryDirectory() as tmpdir:
             sys.argv = [
@@ -67,7 +87,7 @@ class HTMLTests(unittest.TestCase):
 
             out_files = os.listdir(tmpdir)
             self.assertEqual(set(out_files),
-                             {'extra.css', 'index.html', 'js', 'css', 'images', 'fonts'})
+                             {'extra.css', 'extra.js', 'index.html', 'js', 'css', 'images', 'fonts'})
             js_files = os.listdir(os.path.join(tmpdir, 'js'))
             self.assertEqual(set(js_files),
                              {'impress.js', 'hovercraft.js', 'impressConsole.js', 'dummy.js'})

--- a/hovercraft/tests/test_parse.py
+++ b/hovercraft/tests/test_parse.py
@@ -33,7 +33,7 @@ class SlideMakerTests(unittest.TestCase):
         target = (
             b'<document source="&lt;string&gt;" title="Presentation title" '
             b'data-transition-duration="2000" auto-console="True" '
-            b'css-screen="extra.css"><paragraph>This is an advanced '
+            b'css-screen="extra.css" js-body="extra.js"><paragraph>This is an advanced '
             b'presentation. It doesn\'t have a section in the first\nstep, '
             b'meaning the first step will not be a step at all, but a sort of\n'
             b'introductory comment about the presentation, that will not show up '


### PR DESCRIPTION
Added one test for this and modified a few others to test javascript addition.
Added an additional break clause ('?') for copying of javascript resources, to handle URL parameters.
Added fix for row 146/164 where OTHER_RESOURCE was not imported previously.
Minor fix for documentation regarding css.

Fixes #72.
See enclosed file for an example of what I wanted to do:
[example.txt](https://github.com/regebro/hovercraft/files/170478/example.txt)