### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -105,7 +105,7 @@ Changes
 - #9: All positioning variables except data-x and data-y are now "sticky" so
       they will keep their previous value if not defined.
 
-- Documentation on https://hovercraft.readthedocs.org/
+- Documentation on https://hovercraft.readthedocs.io/
 
 
 1.0b1 (2013-02-07)

--- a/README.rst
+++ b/README.rst
@@ -63,5 +63,5 @@ Other contributors (see CHANGES.txt for details):
 
 .. _impress.js: http://github.com/bartaz/impress.js
 .. _demo: http://regebro.github.com/hovercraft
-.. _readthedocs.org: https://hovercraft.readthedocs.org/
+.. _readthedocs.org: https://hovercraft.readthedocs.io/
 .. _pip: http://www.pip-installer.org/en/latest/

--- a/docs/examples/hovercraft.rst
+++ b/docs/examples/hovercraft.rst
@@ -19,7 +19,7 @@ If you are seeing this text, and not reading this as source code, you are
 doing it wrong! It's going to be confusing and not very useful.
 
 Use The Source, Luke! But first you probably want to read through the
-official documentation at https://hovercraft.readthedocs.org/
+official documentation at https://hovercraft.readthedocs.io/
 
 ----
 

--- a/docs/examples/positions.rst
+++ b/docs/examples/positions.rst
@@ -14,7 +14,7 @@ If you are seeing this text, and not reading this as source code, you are
 doing it wrong! It's going to be confusing and not very useful.
 
 Use The Source, Luke! But first you probably want to read through the
-official documentation at https://hovercraft.readthedocs.org/
+official documentation at https://hovercraft.readthedocs.io/
 There are links to the source code in the Examples section.
 
 ----

--- a/docs/examples/tutorial.rst
+++ b/docs/examples/tutorial.rst
@@ -9,7 +9,7 @@ presentations. It will show the most important features of Hovercraft! with
 explanations.
 
 Hopefully you ended up here by the link from the official documentation at
-https://hovercraft.readthedocs.org/ . If not, you probably want to go there
+https://hovercraft.readthedocs.io/ . If not, you probably want to go there
 and read through it first.
 
 This tutorial is meant to be read as source code, not in any HTML form, so if


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.
