### PR TITLE
Option to show slide numbers

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ Changes
 2.4 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Option to display slide numbers [frederikmoellers]
 
 
 2.3 (2017-04-12)

--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,8 @@ Other contributors (see CHANGES.txt for details):
 
 * Adam Johnson [adamchainz]
 
+* Frederik Möllers [frederikmoellers]
+
 .. _impress.js: http://github.com/bartaz/impress.js
 .. _demo: http://regebro.github.com/hovercraft
 .. _readthedocs.org: https://hovercraft.readthedocs.io/

--- a/docs/presentations.rst
+++ b/docs/presentations.rst
@@ -270,7 +270,8 @@ them first in the document, or first on a slide.
 
 Any fields you put first in a document will be rendered into attributes on
 the main impress.js ``<div>``. The only ones that Hovercraft! will use are
-``data-transition-duration``, ``skip-help`` and ``auto-console``.
+``data-transition-duration``, ``skip-help``, ``auto-console`` and
+``slide-numbers``.
 
 Any fields you put first in a slide will be rendered into attributes on the
 slide ``<div>``. This is used primarily to set the position/zoom/rotation of

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -57,9 +57,13 @@ Optional arguments:
     ``-s, --skip-help`` Do not show the initial help popup. You can also set
         this by having ``:skip-help: true`` first in the presentation.
 
-
     ``-n, --skip-notes``
         Do not include presenter notes in the output.
+
+    ``-N, --slide-numbers``
+        Show the current slide number on the slide itself and in the presenter
+        console. You can also set this by having ``slide-numbers: true`` in
+        the presentation preamble.
 
     ``-p PORT, --port PORT``
         The address and port that the server uses. Ex 8080 or

--- a/hovercraft/__init__.py
+++ b/hovercraft/__init__.py
@@ -135,6 +135,11 @@ def main():
         default=os.environ.get('HOVERCRAFT_MATHJAX', 'https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML'),
         help=('The URL to the mathjax library.'
               ' (It will only be used if you have rST ``math::`` in your document)'))
+    parser.add_argument(
+        '-N',
+        '--slide-numbers',
+        action='store_true',
+        help=('Show slide numbers during the presentation.'))
 
     args = parser.parse_args()
 

--- a/hovercraft/generate.py
+++ b/hovercraft/generate.py
@@ -17,7 +17,7 @@ class ResourceResolver(etree.Resolver):
             return self.resolve_string(resource_string(__name__, filename), context)
 
 
-def rst2html(filepath, template_info, auto_console=False, skip_help=False, skip_notes=False, mathjax=False):
+def rst2html(filepath, template_info, auto_console=False, skip_help=False, skip_notes=False, mathjax=False, slide_numbers=False):
     # Read the infile
     with open(filepath, 'rb') as infile:
         rststring = infile.read()
@@ -79,6 +79,10 @@ def rst2html(filepath, template_info, auto_console=False, skip_help=False, skip_
     if skip_help:
         tree.attrib['skip-help'] = 'True'
 
+    # If the slide numbers should be displayed, set an attribute on the document:
+    if slide_numbers:
+        tree.attrib['slide-numbers'] = 'True'
+
     # We need to set up a resolver for resources, so we can include the
     # reST.xsl file if so desired.
     parser = etree.XMLParser()
@@ -134,7 +138,8 @@ def generate(args):
     # Make the resulting HTML
     htmldata, dependencies = rst2html(args.presentation, template_info,
                                       args.auto_console, args.skip_help,
-                                      args.skip_notes, args.mathjax)
+                                      args.skip_notes, args.mathjax,
+                                      args.slide_numbers)
     source_files.extend(dependencies)
 
     # Write the HTML out

--- a/hovercraft/templates/default/css/hovercraft.css
+++ b/hovercraft/templates/default/css/hovercraft.css
@@ -46,3 +46,14 @@
 #hovercraft-help.disabled {
     display: none;
 }
+
+/* Slide numbers */
+
+div#slide-number
+{
+    bottom: 1em;
+    font-size: 5vh;
+    position: absolute;
+    right: 2.5em;
+    text-align: right;
+}

--- a/hovercraft/templates/default/css/impressConsole.css
+++ b/hovercraft/templates/default/css/impressConsole.css
@@ -83,3 +83,10 @@ div#timer {
     text-align: center;
     float: left;
 }
+
+div#counter {
+    margin-left: 2em;
+    margin-right: 2em;
+    text-align: right;
+    float: right;
+}

--- a/hovercraft/templates/default/js/hovercraft.js
+++ b/hovercraft/templates/default/js/hovercraft.js
@@ -35,3 +35,10 @@ if (impressConsole) {
         consoleWindow = console().open();
     }
 }
+
+// Function updating the slide number counter
+function update_slide_number(evt)
+{
+    var step = evt.target.attributes['step'].value;
+    document.getElementById('slide-number').innerText = parseInt(step) + 1;
+}

--- a/hovercraft/templates/default/js/impressConsole.js
+++ b/hovercraft/templates/default/js/impressConsole.js
@@ -33,6 +33,7 @@
           '<div id="clock">00:00:00 AM</div>' +
           '<div id="timer" onclick="timerReset()">00m 00s</div>' +
           '<div id="status">Loading</div>' +
+          '<div id="counter">Slide <span id="slide-number">1</span></div>' +
         '</div>' +
         '</body></html>';
 
@@ -136,6 +137,10 @@
                 if (preView.src !== preSrc) {
                     preView.src = preSrc;
                 }
+
+                // Update the slide number
+                var slide_number = parseInt(document.querySelector('.active').attributes['step'].value) + 1;
+                consoleWindow.document.getElementById('slide-number').innerHTML = '' + slide_number;
 
                 consoleWindow.document.getElementById('status').innerHTML = '<span style="color: green">Ready</span>';
             }

--- a/hovercraft/templates/default/template.xsl
+++ b/hovercraft/templates/default/template.xsl
@@ -92,6 +92,11 @@ xmlns="http://www.w3.org/1999/xhtml">
         </xsl:for-each>
       </div>
     </xsl:for-each>
+	<xsl:if test="/document/@slide-numbers">
+	  <div id="slide-number" class="slide-number">
+	    1
+	  </div>
+    </xsl:if>
 
     <div id="hovercraft-help">
       <xsl:if test="/document/@skip-help">
@@ -110,6 +115,11 @@ xmlns="http://www.w3.org/1999/xhtml">
         <xsl:copy-of select="@*"/>
       </script>
     </xsl:for-each>
+    <xsl:if test="/document/@slide-numbers">
+	  <script type="text/javascript">
+        document.getElementById("impress").addEventListener("impress:stepenter", update_slide_number, false);
+	  </script>
+    </xsl:if>
 
 </body>
 </html>

--- a/hovercraft/templates/simple/css/hovercraft.css
+++ b/hovercraft/templates/simple/css/hovercraft.css
@@ -46,3 +46,14 @@
 .impress-enabled #hovercraft-help.show {
     display: block;
 }
+
+/* Slide numbers */
+
+div#slide-number
+{
+    bottom: 1em;
+    font-size: 5vh;
+    position: absolute;
+    right: 2.5em;
+    text-align: right;
+}

--- a/hovercraft/templates/simple/js/hovercraft.js
+++ b/hovercraft/templates/simple/js/hovercraft.js
@@ -35,3 +35,10 @@ if (console) {
         consoleWindow = console().open();
     }
 }
+
+// Function updating the slide number counter
+function update_slide_number(evt)
+{
+    var step = evt.target.attributes['step'].value;
+    document.getElementById('slide-number').innerText = parseInt(step) + 1;
+}

--- a/hovercraft/templates/simple/template.xsl
+++ b/hovercraft/templates/simple/template.xsl
@@ -69,6 +69,11 @@ xmlns="http://www.w3.org/1999/xhtml">
         </xsl:for-each>
       </div>
     </xsl:for-each>
+	<xsl:if test="/document/@slide-numbers">
+	  <div id="slide-number" class="slide-number">
+	    1
+	  </div>
+    </xsl:if>
 
     <div id="hovercraft-help">
       <xsl:if test="not(/document/@skip-help)">
@@ -88,6 +93,11 @@ xmlns="http://www.w3.org/1999/xhtml">
         <xsl:copy-of select="@*"/>
       </script>
     </xsl:for-each>
+    <xsl:if test="/document/@slide-numbers">
+	  <script type="text/javascript">
+        document.getElementById("impress").addEventListener("impress:stepenter", update_slide_number, false);
+	  </script>
+    </xsl:if>
 
 </body>
 </html>


### PR DESCRIPTION
Slide numbers can be enabled by either using the `-N`/`--slide-numbers`
command line switch or by putting `:slide-numbers: true` in the
presentation preamble. The are shown in the bottom right corner of the
presentation by default and can be customised using CSS (including their position). In the
presenter console (default template), the current slide number is shown
next to the status ("Moving"/"Ready").

This is a more thoroughly implemented version of PR #108. I also updated the docs, included a command-line switch and included a slide counter in the presenter console of the default template.