### PR TITLE
Jump to arbitrary slides

### DIFF
--- a/hovercraft/templates/default/js/goto_slide.js
+++ b/hovercraft/templates/default/js/goto_slide.js
@@ -1,0 +1,22 @@
+// Keypress handler to go to a specific slide
+function goto_slide()
+{
+    var key = event.charCode || event.keyCode;
+    // 103 = "g"
+    if(key == 103)
+    {
+        var target = prompt("Enter slide number");
+        if (isNaN(target)) {
+            var goto_status = impress().goto(target);
+        } else {
+            // goto(0) goes to step-1, so substract 1
+            var goto_status = impress().goto(parseInt(target) - 1);
+        }
+        if (goto_status === false) {
+            alert("Slide not found: '" + target + "'");
+        }
+    }
+}
+
+// register "g" key handler to jump to a slide
+document.addEventListener("keypress", goto_slide);

--- a/hovercraft/templates/default/js/impressConsole.js
+++ b/hovercraft/templates/default/js/impressConsole.js
@@ -18,6 +18,7 @@
     var consoleTemplate = '<!DOCTYPE html>' +
         '<html id="impressconsole"><head>' +
           '<link rel="stylesheet" type="text/css" media="screen" href="{{cssFile}}">' +
+          '<script type="text/javascript" src="js/goto_slide.js" defer="defer"></script>' +
         '</head><body>' +
         '<div id="console">' +
           '<div id="views">' +

--- a/hovercraft/templates/default/template.cfg
+++ b/hovercraft/templates/default/template.cfg
@@ -8,3 +8,4 @@ css = css/hovercraft.css
 js-body = js/impress.js
           js/impressConsole.js
           js/hovercraft.js
+          js/goto_slide.js

--- a/hovercraft/templates/default/template.xsl
+++ b/hovercraft/templates/default/template.xsl
@@ -123,6 +123,7 @@ xmlns="http://www.w3.org/1999/xhtml">
         <tr><th>Right, Down, Page Down</th><td>Next slide</td></tr>
         <tr><th>Left, Up, Page Up</th><td>Previous slide</td></tr>
         <tr><th>P</th><td>Open presenter console</td></tr>
+        <tr><th>G</th><td>Go to slide</td></tr>
         <tr><th>H</th><td>Toggle this help</td></tr>
       </table>
     </div>

--- a/hovercraft/tests/test_data/__init__.py
+++ b/hovercraft/tests/test_data/__init__.py
@@ -176,12 +176,14 @@ HTML_OUTPUTS = {
         b'<table><tr><th>Space</th><td>Forward</td></tr><tr><th>'
         b'Right, Down, Page Down</th><td>Next slide</td></tr><tr><th>'
         b'Left, Up, Page Up</th><td>Previous slide</td></tr><tr><th>P</th>'
-        b'<td>Open presenter console</td></tr><tr><th>H</th><td>Toggle '
-        b'this help</td></tr></table></div><script type="text/javascript" '
-        b'src="js/impress.js"></script><script type="text/javascript" '
-        b'src="js/impressConsole.js"></script><script type="text/javascript" '
-        b'src="js/hovercraft.js"></script><script type="text/javascript" '
-        b'src="extra.js"></script></body></html>'
+        b'<td>Open presenter console</td></tr><tr><th>G</th><td>Go to slide'
+        b'</td></tr><tr><th>H</th><td>Toggle this help</td></tr></table>'
+        b'</div><script type="text/javascript" src="js/impress.js"></script>'
+        b'<script type="text/javascript" src="js/impressConsole.js">'
+        b'</script><script type="text/javascript" src="js/hovercraft.js">'
+        b'</script><script type="text/javascript" src="js/goto_slide.js">'
+        b'</script><script type="text/javascript" src="extra.js"></script>'
+        b'</body></html>'
     ),
 
     'presenter-notes': (

--- a/hovercraft/tests/test_hovercraft.py
+++ b/hovercraft/tests/test_hovercraft.py
@@ -164,7 +164,7 @@ class HTMLTests(unittest.TestCase):
 
             js_files = os.listdir(os.path.join(tmpdir, 'js'))
             self.assertEqual(set(js_files), {'impress.js', 'hovercraft.js',
-                                             'impressConsole.js'})
+                                             'impressConsole.js', 'goto_slide.js'})
             css_files = os.listdir(os.path.join(tmpdir, 'css'))
             self.assertEqual(set(css_files), {'hovercraft.css',
                                               'impressConsole.css', 'highlight.css'})


### PR DESCRIPTION
Introduce a new hotkey "g" which prompts for a slide number or name (the
slide's ID) and then jumps directly to this slide. Can be pressed in
either the presentation or the console window.