### PR TITLE
Finish renaming console to impressConsole

### DIFF
--- a/hovercraft/templates/default/js/hovercraft.js
+++ b/hovercraft/templates/default/js/hovercraft.js
@@ -40,7 +40,7 @@ if (impressConsole) {
     impressConsole().registerKeyEvent([72], help, window);
 
     if (impressattrs.hasOwnProperty('auto-console') && impressattrs['auto-console'].value.toLowerCase() === 'true') {
-        consoleWindow = console().open();
+        consoleWindow = impressConsole().open();
     }
 }
 

--- a/hovercraft/templates/simple/js/hovercraft.js
+++ b/hovercraft/templates/simple/js/hovercraft.js
@@ -40,7 +40,7 @@ if (impressConsole) {
     impressConsole().registerKeyEvent([72], help, window);
 
     if (impressattrs.hasOwnProperty('auto-console') && impressattrs['auto-console'].value.toLowerCase() === 'true') {
-        consoleWindow = console().open();
+        consoleWindow = impressConsole().open();
     }
 }
 

--- a/hovercraft/tests/test_data/maximal/js/hovercraft.js
+++ b/hovercraft/tests/test_data/maximal/js/hovercraft.js
@@ -40,7 +40,7 @@ if (impressConsole) {
     impressConsole().registerKeyEvent([72], help, window);
 
     if (impressattrs.hasOwnProperty('auto-console') && impressattrs['auto-console'].value.toLowerCase() === 'true') {
-        consoleWindow = console().open();
+        consoleWindow = impressConsole().open();
     }
 }
 


### PR DESCRIPTION
https://github.com/regebro/impress-console/commit/5042d2577f4fad767e4341b93e18fd60f191e549 renamed `console` to `impressConsole` to avoid a name conflict. This commit renames three other references to `console()` to `impressConsole()`.

Fixes https://github.com/regebro/hovercraft/issues/150