### PR TITLE
Add documentation how to add presenter notes

### DIFF
--- a/docs/presentations.rst
+++ b/docs/presentations.rst
@@ -113,6 +113,15 @@ bad network connectivity.
 This can be solved by specifying a local copy of mathjax with the --mathjax
 command line.
 
+Presenter notes
+---------------
+
+To add presenter notes, that will be displayed in the presenter console, use the
+following syntax:
+
+    .. note::
+    
+        Here goes the presenter note.
 
 External files
 --------------


### PR DESCRIPTION
I couldn't find how to add presenter notes in the docs. I found an example in the source of the demo slides. I thought it would be helpful to add this to the documentation.