### PR TITLE
Adds testing against python3.7 and fixes nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,19 @@
 language: python
 os:
   - linux
-python:
-  - "3.5"
-  - "3.6"
-  - "nightly"
+matrix:
+  fast_finish: true
+  include:
+    - python: 3.5
+    - python: 3.6
+    - python: 3.7
+      sudo: required
+      dist: xenial
+    - python: nightly
+      sudo: required
+      dist: xenial
+  allow_failures:
+    - python: nightly
 # command to run tests
 install: python setup.py develop
 script: python setup.py test


### PR DESCRIPTION
Fix for testing against python3.7 and later in TravisCI.  https://github.com/travis-ci/travis-ci/issues/9815

Set it to allow for nightly to fail without failing the overall build as well.