### PR TITLE
Adding directive plugins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,37 +1,223 @@
+
+# Created by https://www.gitignore.io/api/linux,vim,emacs,python,python
+# Edit at https://www.gitignore.io/?templates=linux,vim,emacs,python,python
+
+### Emacs ###
+# -*- mode: gitignore; -*-
+*~
+\#*\#
+/.emacs.desktop
+/.emacs.desktop.lock
+*.elc
+auto-save-list
+tramp
+.\#*
+
+# Org-mode
+.org-id-locations
+*_archive
+
+# flymake-mode
+*_flymake.*
+
+# eshell files
+/eshell/history
+/eshell/lastdir
+
+# elpa packages
+/elpa/
+
+# reftex files
+*.rel
+
+# AUCTeX auto folder
+/auto/
+
+# cask packages
+.cask/
+dist/
+
+# Flycheck
+flycheck_*.el
+
+# server auth directory
+/server/
+
+# projectiles files
+.projectile
+
+# directory configuration
+.dir-locals.el
+
+# network security
+/network-security.data
+
+
+### Linux ###
+
+# temporary files which can be created if a process still has a handle open of a deleted file
+.fuse_hidden*
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+# .nfs files are created when an open file is removed but is still being accessed
+.nfs*
+
+### Python ###
+# Byte-compiled / optimized / DLL files
+__pycache__/
 *.py[cod]
-pyvenv.cfg
-__pycache__
-*.*~
+*$py.class
 
 # C extensions
 *.so
 
-# Packages
-*.egg
-*.egg-info
-dist
-build
-eggs
-parts
-bin
-var
-sdist
-develop-eggs
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
+*.egg-info/
 .installed.cfg
-lib
-lib64
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
 
 # Installer logs
 pip-log.txt
+pip-delete-this-directory.txt
 
 # Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
 .coverage
-.tox
+.coverage.*
+.cache
 nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo
+*.pot
 
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+.python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+### Vim ###
+# Swap
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Session
+Session.vim
+Sessionx.vim
+
+# Temporary
+.netrwhist
+# Auto-generated tag files
+tags
+# Persistent undo
+[._]*.un~
+
+# End of https://www.gitignore.io/api/linux,vim,emacs,python,python
+
+# Generated using ignr.py - github.com/Antrikshy/ignr.py
+
+#------------------------------------------------------------------------------
+# Custom
+#------------------------------------------------------------------------------
 # Mr Developer
 .mr.developer.cfg
 .project

--- a/hovercraft/directive/null.py
+++ b/hovercraft/directive/null.py
@@ -1,0 +1,14 @@
+# TODO - Remove this file.  It is only here to demonstrate how to implement a
+# directive plugin.
+from docutils import nodes
+from docutils.parsers.rst import Directive, directives
+
+
+class Null(Directive):
+    def run(self):
+        para = nodes.paragraph(text='Example null directive')
+        return [para]
+
+
+def register(_):
+    directives.register_directive('null', Null)

--- a/hovercraft/generate.py
+++ b/hovercraft/generate.py
@@ -128,6 +128,10 @@ def copy_resource(filename, sourcedir, targetdir):
     sourcepath = os.path.join(sourcedir, filename)
     targetpath = os.path.join(targetdir, filename)
 
+    if not os.path.exists(sourcepath) and os.path.exists(targetpath):
+        # Generated image, no source file available
+        return None  # No monitoring needed
+
     if (os.path.exists(targetpath) and
         os.path.getmtime(sourcepath) <= os.path.getmtime(targetpath)):
         # File has not changed since last copy, so skip.


### PR DESCRIPTION
Hey all!
Before I proceed, please keep in mind that this is a proof of concept/work in progress.  I would like to get general feedback before finishing up the code, adding tests **(including fixing the existing tests)**, updating the documentation, and so on.

I just want to make sure I'm heading the the correct general direction first.

There are a couple of high level parts to this:

1. Add the `--directive-plugin|-D [DIRECTIVE_PLUGIN_MODULE]` argument to the `hovercraft` command to make it easier to add third-party _Docutils_ directives. 
2. Simplify/standardize adding builtin _Docutil_ directives.  Take a peek at `hovercraft/directive/null.py` in the PR.

I started implementing a [PlantUML](http://plantuml.com/) plugin which can be found at [pedrohdz/muextensions](https://github.com/pedrohdz/muextensions).  The documentation on how to use it with _Hovercraft!_ is in the [README](https://github.com/pedrohdz/muextensions#hovercraft).  Here is the general idea:

```bash
python3.7 -m venv .venv
source .venv/bin/activate
pip install -U pip
pip install muextensions \
    https://github.com/pedrohdz/hovercraft/archive/directives.zip
hovercraft --directive-plugin muextensions.contrib.hovercraft demo.rst
```

Please let me know what you all think.  I can add the finishing touches if this is looking good so far, along with implementing any recommendations.

Thanks!