### PR TITLE
Video/Audio support. Copy files defined in <source> tags + add docs for video and audio

### DIFF
--- a/docs/presentations.rst
+++ b/docs/presentations.rst
@@ -66,6 +66,24 @@ You can include images::
 As you see you can also specify height and width and loads of other parameters_, but they
 are all optional.
 
+
+You can also include videos::
+
+    .. raw::
+        <video width="100%" controls>
+            <source src="./path/to/your/video.mp4" type="video/mp4">
+            Your browser does not support the video element.
+        </video>
+
+or audio::
+
+    .. raw::
+        <audio controls>
+            <source src="./path/to/your/audio.mp3" type="audio/mpeg">
+            Your browser does not support the audio element.
+        </audio>
+
+
 And you can mark text as being preformatted. You do that by ending the
 previous row with double colons, or have a row of double colons by itself::
 

--- a/hovercraft/generate.py
+++ b/hovercraft/generate.py
@@ -202,11 +202,14 @@ def generate(args):
     # Copy supporting files
     source_files.update(template_info.copy_resources(args.targetdir))
 
-    # Copy images from the source:
+    # Copy files from the source:
     sourcedir = os.path.split(os.path.abspath(args.presentation))[0]
     tree = html.fromstring(htmldata)
     for image in tree.iterdescendants("img"):
         filename = image.attrib["src"]
+        source_files.add(copy_resource(filename, sourcedir, args.targetdir))
+    for source in tree.iterdescendants('source'):
+        filename = source.attrib['src']
         source_files.add(copy_resource(filename, sourcedir, args.targetdir))
 
     RE_CSS_URL = re.compile(br"""url\(['"]?(.*?)['"]?[\)\?\#]""")


### PR DESCRIPTION
This change is a quick and easy fix for the support of video and audio files.
I know there is another pullrequest here for this feature, but it seems it has been there forever and won't get merged in the near future.
My implementation modifies the generate.py to also look for` <source>` tags and then grab the files specified in "src" and copy them over. So it works fine with both the live server and the export.
I also modified the documentation to show how to include a video or an audio at this moment. Maybe it is not the nicest solution as we have to use the "raw" directive. But it is definitely an improvement over the current state of not handling it at all.
So I think it should be ok for now. If the proper implementation gets merged it can of course be changed. But it would be a pitty if we couldn't really use videos with hovercraft! Because hovercraft! is awesome!