### PR TITLE
Attempt at supporting superscipt and subscript

### DIFF
--- a/hovercraft/templates/reST.xsl
+++ b/hovercraft/templates/reST.xsl
@@ -203,6 +203,28 @@ Modification by Carl Mayer, 2013:
         </p>
 </xsl:template>
 
+<xsl:template match="superscript">
+	<sup>
+        <xsl:if test="@classes">
+	<xsl:attribute name="class">
+		<xsl:value-of select="@classes" />
+	</xsl:attribute>
+        </xsl:if>
+	<xsl:apply-templates />
+        </sup>
+</xsl:template>
+
+<xsl:template match="subscript">
+	<sub>
+        <xsl:if test="@classes">
+	<xsl:attribute name="class">
+		<xsl:value-of select="@classes" />
+	</xsl:attribute>
+        </xsl:if>
+	<xsl:apply-templates />
+        </sub>
+</xsl:template>
+
 <xsl:template match="container">
 	<div>
         <xsl:if test="@classes">


### PR DESCRIPTION
XSLT was removing superscript/subscript, this commit is a first shot at trying to let them pass through the transformation to HTML.

https://docutils.sourceforge.io/docs/ref/rst/roles.html#superscript

I am not too familiar with XSLT, so this is just a hackish attempt, maybe there are more proper ways to solve this.

I welcome any feedback about it!