### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,19 @@ matrix:
     - python: nightly
       sudo: required
       dist: xenial
+    #power_jobs
+    - python: 3.6
+      arch: pp64le
+    - python: 3.7
+      arch: ppc64le
+    - python: 3.8
+      arch: ppc64le
+      sudo: required
+      dist: xenial
+    - python: nightly
+      arch: ppc64le
+      sudo: required
+      dist: xenial       
   allow_failures:
     - python: nightly
 # command to run tests


### PR DESCRIPTION
Thank you for the code.
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
